### PR TITLE
Add missing PyYAML dependency

### DIFF
--- a/scraper/requirements.txt
+++ b/scraper/requirements.txt
@@ -2,4 +2,4 @@ requests
 beautifulsoup4
 lxml
 python-dateutil
-ruamel.yaml
+PyYAML


### PR DESCRIPTION
## Summary
- fix ModuleNotFoundError in scraper by adding PyYAML requirement

## Testing
- ⚠️ `pip install -r scraper/requirements.txt` (failed: Could not find a version that satisfies the requirement PyYAML)
- ⚠️ `python scraper/scrape.py` (failed: ModuleNotFoundError: No module named 'yaml')

------
https://chatgpt.com/codex/tasks/task_e_68c0797730188331852995491a682f54