### PR TITLE
Align experience patterns indentation

### DIFF
--- a/scraper/companies.yaml
+++ b/scraper/companies.yaml
@@ -168,8 +168,8 @@ experience:
   patterns:
     - "\\b(2|3|4|5)\\+?\\s*years?\\b"
     - "\\b2\\s*-\\s*5\\s*years?\\b"
-      - "\\b(2|3|4|5|6|7)\\+?\\s*years?\\b"
-      - "\\b2\\s*-\\s*7\\s*years?\\b"
+    - "\\b(2|3|4|5|6|7)\\+?\\s*years?\\b"
+    - "\\b2\\s*-\\s*7\\s*years?\\b"
     - "\\bmid\\s*level\\b"
 
 locations_priority:


### PR DESCRIPTION
## Summary
- fix indentation in experience patterns list in companies.yaml

## Testing
- `python -m py_compile scraper/scrape.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c31ec739488331b9fb5a73f26091ca