### PR TITLE
Consolidate CSV path and remove legacy jobs.csv

### DIFF
--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -39,10 +39,10 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add jobs.csv
+          git add scraper/Jobs.csv
           if git diff --cached --quiet; then
             echo "No changes."
           else
-            git commit -m "Update jobs.csv [auto]"
+            git commit -m "Update Jobs.csv [auto]"
             git push
           fi

--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ This repository hosts a static website that displays weekly job openings from Ne
 - `style.css` – simple styling.
 - `script.js` – CSV loading and table rendering logic; edit the `CSV_URL` constant if you want to load data from a different CSV or a published Google Sheet.
 - `scraper/` – Python code and configuration for automated scraping:
+  - `scraper/Jobs.csv` – generated job listings.
   - `scraper/companies.yaml` – list of companies and role filters.
   - `scraper/scrape.py` – script that outputs `scraper/Jobs.csv`.
   - `scraper/requirements.txt` – Python dependencies.
-- `jobs.csv` – example data file from the early version of the project. It is not used by default but can serve as a template if you prefer manual updates.
 
 ## Updating the listings
 

--- a/index.html
+++ b/index.html
@@ -32,7 +32,7 @@
     </main>
     <footer>
       <p>
-        The table above is populated from the <code>jobs.csv</code> file in this
+        The table above is populated from the <code>scraper/Jobs.csv</code> file in this
         project. To add new roles, edit that file or connect the page to a
         Google&nbsp;Sheet published in CSV format. See the instructions in the
         README for details.

--- a/jobs.csv
+++ b/jobs.csv
@@ -1,4 +1,0 @@
-Company,Role,Experience,Location,Link
-Astroscale,"シニアセールスエンジニア/ Senior Sales Engineer Tokyo, Sumida-ku Learn More",,Germany,https://astroscale.bamboohr.com/careers/468
-AAC Clyde Space,Project Manager – Delft,,United Kingdom,https://www.aac-clyde.space/jobs/project-manager-delft
-AAC Clyde Space,"Project Manager – Delft The role is to lead allocated projects throughout their lifecycle, delivering successfully against objectives in terms of cost, quality and timescales. The type of projects allocated will be production and development. This will involve working with the engineering team, production processes, inventory management and supply chain. Find out more",,United Kingdom,https://www.aac-clyde.space/jobs/project-manager-delft

--- a/script.js
+++ b/script.js
@@ -83,8 +83,8 @@ document.addEventListener("DOMContentLoaded", () => {
       buildTable(headers, rows.slice(1));
     })
     .catch(err => {
-      console.error("Failed to load jobs.csv:", err);
+      console.error("Failed to load scraper/Jobs.csv:", err);
       const t = ensureTable();
-      t.innerHTML = "<caption>Failed to load jobs.csv</caption>";
+      t.innerHTML = "<caption>Failed to load scraper/Jobs.csv</caption>";
     });
 });


### PR DESCRIPTION
## Summary
- point workflow and UI at `scraper/Jobs.csv` as the sole data source
- update footer and error logs to reference the new path
- drop obsolete `jobs.csv` example and refresh documentation

## Testing
- `node --check script.js` *(fails: node not installed)*
- `apt-get update` *(fails: 403 Forbidden while attempting to install Node)*
- `python3 -m py_compile scraper/scrape.py`


------
https://chatgpt.com/codex/tasks/task_e_68c321f195988331a16b24e9d45b0c3e