### PR TITLE
Remove ATS adapters and rely solely on static scraping

### DIFF
--- a/scraper/scrape.py
+++ b/scraper/scrape.py
@@ -26,13 +26,6 @@ GENERIC_TITLE_PATTERNS = [
     re.compile(r"\bcareers?\b", re.I),
 ]
 
-ATS_PATTERNS = {
-    "greenhouse": re.compile(r"boards\.greenhouse\.io/([^/\"'\s]+)", re.I),
-    "lever":      re.compile(r"jobs\.lever\.co/([^/\"'\s]+)", re.I),
-    "personio":   re.compile(r"([a-z0-9-]+)\.jobs\.personio\.de", re.I),
-    "recruitee":  re.compile(r"([a-z0-9-]+)\.recruitee\.com", re.I),
-}
-
 HEADERS = {"User-Agent": "Mozilla/5.0"}
 
 def normalize_url(u: str) -> str:
@@ -51,11 +44,6 @@ def fetch(url: str) -> str:
     resp = requests.get(url, timeout=20, headers=HEADERS)
     resp.raise_for_status()
     return resp.text
-
-def fetch_json(url: str):
-    r = requests.get(url, timeout=20, headers=HEADERS)
-    r.raise_for_status()
-    return r.json()
 
 def clean_title(t: str) -> str:
     """Collapse whitespace; remove marketing tails; clamp very long blobs."""
@@ -201,134 +189,6 @@ def extract_links_static(base_url: str, html: str, include_pats, exclude_pats):
     return [(title, url) for url, title in by_url.items()]
 
 # =========================
-# ATS adapters
-# =========================
-
-def list_greenhouse(board: str):
-    """Greenhouse public API: https://boards-api.greenhouse.io/v1/boards/{board}/jobs"""
-    url = f"https://boards-api.greenhouse.io/v1/boards/{board}/jobs"
-    data = fetch_json(url)
-    out = []
-    for job in data.get("jobs", []):
-        title = clean_title(job.get("title") or "")
-        link = job.get("absolute_url") or ""
-        if title and link:
-            out.append((title, link))
-    return out
-
-def list_lever(company: str):
-    """Lever public API: https://api.lever.co/v0/postings/{company}?mode=json"""
-    url = f"https://api.lever.co/v0/postings/{company}?mode=json"
-    data = fetch_json(url)
-    out = []
-    for job in data:
-        title = clean_title(job.get("text") or job.get("title") or "")
-        link = job.get("hostedUrl") or job.get("applyUrl") or ""
-        if title and link:
-            out.append((title, link))
-    return out
-
-def list_personio(subdomain: str):
-    """
-    Personio public search JSON.
-    Typical endpoint: https://{sub}.jobs.personio.de/search.json
-    - Some tenants return a dict with "jobPostings": [...]
-    - Others return a list at the root.
-    This function handles both and normalizes (title, link).
-    """
-    url = f"https://{subdomain}.jobs.personio.de/search.json"
-    data = fetch_json(url)
-
-    # Normalize to a list of postings
-    if isinstance(data, dict):
-        postings = (
-            data.get("jobPostings")
-            or data.get("items")
-            or data.get("postings")
-            or []
-        )
-    elif isinstance(data, list):
-        postings = data
-    else:
-        postings = []
-
-    out = []
-    for job in postings:
-        if not isinstance(job, dict):
-            continue
-
-        # Title fields vary: "name", "title", "position"
-        title = job.get("name") or job.get("title") or job.get("position") or ""
-
-        # URL fields vary:
-        # - "url" may be relative or absolute
-        # - some return "postingUrl" or "urls" dict
-        link = (
-            job.get("url")
-            or job.get("postingUrl")
-            or (job.get("urls") or {}).get("careers")
-            or ""
-        )
-
-        # Build absolute URL if needed
-        if link and not link.startswith("http"):
-            link = f"https://{subdomain}.jobs.personio.de{link}"
-
-        title = clean_title(title)
-        if title and link:
-            out.append((title, link))
-
-    return out
-
-def list_recruitee(subdomain: str):
-    """Recruitee public API: https://{sub}.recruitee.com/api/offers/"""
-    url = f"https://{subdomain}.recruitee.com/api/offers/"
-    data = fetch_json(url)
-    out = []
-    for item in data.get("offers", []):
-        title = clean_title(item.get("title") or "")
-        slug = item.get("slug") or ""
-        link = f"https://{subdomain}.recruitee.com/o/{slug}" if slug else ""
-        if title and link:
-            out.append((title, link))
-    return out
-
-def auto_detect_ats(html: str):
-    """Try to infer ATS provider + token from page HTML."""
-    for ats, rx in ATS_PATTERNS.items():
-        m = rx.search(html or "")
-        if m:
-            token = m.group(1)
-            return ats, token
-    return None, None
-
-def list_from_ats(ats_cfg: dict, html: str):
-    """Return [(title, link)] via explicit ATS config or auto-detection."""
-    if ats_cfg:
-        t = (ats_cfg.get("type") or "").strip().lower()
-        if t == "greenhouse" and ats_cfg.get("board"):
-            return list_greenhouse(ats_cfg["board"])
-        if t == "lever" and ats_cfg.get("company"):
-            return list_lever(ats_cfg["company"])
-        if t == "personio" and ats_cfg.get("subdomain"):
-            return list_personio(ats_cfg["subdomain"])
-        if t == "recruitee" and ats_cfg.get("subdomain"):
-            return list_recruitee(ats_cfg["subdomain"])
-
-    # fallback: try auto-detection
-    ats, token = auto_detect_ats(html)
-    if ats == "greenhouse":
-        return list_greenhouse(token)
-    if ats == "lever":
-        return list_lever(token)
-    if ats == "personio":
-        return list_personio(token)
-    if ats == "recruitee":
-        return list_recruitee(token)
-
-    return []
-
-# =========================
 # Main
 # =========================
 
@@ -349,8 +209,6 @@ def main():
     for comp in cfg.get("companies", []):
         name = (comp.get("name") or "").strip()
         careers_url = (comp.get("careers_url") or "").strip()
-        ats_cfg = comp.get("ats") or {}
-
         if not name or not careers_url:
             continue
 
@@ -360,14 +218,9 @@ def main():
             print(f"[warn] {name}: fetch failed: {e}", file=sys.stderr)
             continue
 
-        # 1) Try static HTML first
         items = extract_links_static(careers_url, html, include_pats, exclude_pats)
 
-        # 2) If nothing found, try ATS adapters (explicit or auto-detect)
-        if not items:
-            items = list_from_ats(ats_cfg, html)
-
-        # Filter by include/exclude again (for ATS results) and de-dup by URL
+        # Filter by include/exclude and de-dup by URL
         for title, href in items:
             if not matches(title, include_pats, exclude_pats):
                 continue


### PR DESCRIPTION
## Summary
- delete ATS-specific patterns and adapter functions from scraper
- simplify `main()` to only use `extract_links_static`

## Testing
- `python -m py_compile scraper/scrape.py`
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c6a38047cc833181708cdcae5c4aac